### PR TITLE
fix(build): raise Node heap to stop Cloudflare CI out-of-memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 astro build",
     "preview": "pnpm run build && wrangler dev",
     "astro": "astro",
     "typecheck": "astro check",


### PR DESCRIPTION
## Problem
Every Cloudflare Workers build on `main` has been failing with:
```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
ELIFECYCLE Command failed with exit code 134
```
The failure is in the `astro build` step ("Building static entrypoints"), **before** deploy. The site grew through the audit to 49 pages with React islands + build-time image processing, pushing peak build memory past Node's default ~2 GB heap cap. It builds locally only because dev machines have more RAM than the CF builder.

**Impact:** because this build gates deploys, production has not updated since the audit work merged — the live site still serves the old homepage.

## Fix
```diff
- "build": "astro build",
+ "build": "NODE_OPTIONS=--max-old-space-size=4096 astro build",
```
Cloudflare's build environment has ~8 GB RAM; this lets Node use 4 GB. Verified locally: heap limit rises to ~4 GB and the build completes (49 pages). The real proof is this PR's CI going green.

## Why a separate hotfix
This is isolated from the open dependency PR (#191) so `main` can go green — and production can deploy — independent of the major version bumps there. Once merged, I'll rebase #191 onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)