### PR TITLE
fix(images): pre-optimize at build time so the hero image loads

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,5 +37,11 @@ export default defineConfig({
       },
   },
 
-  adapter: cloudflare(),
+  adapter: cloudflare({
+      // Optimize images at build time into static /_astro/*.webp files.
+      // The default ("cloudflare") serves images via a runtime /_image endpoint
+      // backed by Cloudflare Images, which 404s unless that feature is enabled
+      // on the account — breaking the hero image on this static site.
+      imageService: "compile",
+  }),
 });


### PR DESCRIPTION
## Problem
The main hero image doesn't display on production — it falls back to alt text.

## Cause
The audit added a `getImage()` WebP srcset for the hero. `@astrojs/cloudflare` defaults to `imageService: 'cloudflare'`, which serves optimized images from a **runtime `/_image` endpoint** backed by Cloudflare Images. That feature isn't enabled on this account, so the endpoint 404s:

```
GET /_image?href=/_astro/header.*.jpg&f=webp  ->  404
GET /_astro/header.*.jpg (raw asset)          ->  200
```

## Fix
This is a static-output site, so switch to `imageService: 'compile'` — images are optimized with sharp at **build time** into static `/_astro/*.webp` files, served directly. No runtime endpoint, no Cloudflare Images dependency.

Verified locally: build now logs "compile-time image optimization", emits `header.*.webp`, and the hero `src` in `index.html` is `/_astro/header.*.webp` instead of `/_image?...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)